### PR TITLE
small improvement by reducing the number of rows processed by the database for GetTrackedTables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -464,9 +464,8 @@ Uses the following SQL:
 <a id='snippet-GetTrackedTablesSql'></a>
 ```cs
 select t.Name
-from sys.tables as t left join
+from sys.tables as t inner join
   sys.change_tracking_tables as c on t.[object_id] = c.[object_id]
-where c.[object_id] is not null
 ```
 <sup><a href='/src/Delta/DeltaExtensions_Sql.cs#L76-L81' title='Snippet source file'>snippet source</a> | <a href='#snippet-GetTrackedTablesSql' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/Delta/DeltaExtensions_Sql.cs
+++ b/src/Delta/DeltaExtensions_Sql.cs
@@ -75,9 +75,8 @@ set change_tracking = on
         command.CommandText = @"
 -- begin-snippet: GetTrackedTablesSql
 select t.Name
-from sys.tables as t left join
+from sys.tables as t inner join
   sys.change_tracking_tables as c on t.[object_id] = c.[object_id]
-where c.[object_id] is not null
 -- end-snippet";
         await using var reader = await command.ExecuteReaderAsync(cancel);
         var list = new List<string>();


### PR DESCRIPTION
- use inner join instead of left join to reduce the number of rows processed by the database