### PR TITLE
Add MySql/MariaDB support

### DIFF
--- a/src/Delta/DeltaExtensions_ConnectionDiscovery.cs
+++ b/src/Delta/DeltaExtensions_ConnectionDiscovery.cs
@@ -20,7 +20,14 @@ public static partial class DeltaExtensions
             return (npgsqlConnection, transaction);
         }
 
-        throw new("Could not find connection type. Tried Microsoft.Data.SqlClient.SqlConnection and Npgsql.NpgsqlTransaction");
+        var mySqlConnection = Type.GetType("MySqlConnector.MySqlConnection, MySqlConnector");
+        if (mySqlConnection != null)
+        {
+            var transaction = mySqlConnection.Assembly.GetType("MySqlConnector.MySqlTransaction")!;
+            return (mySqlConnection, transaction);
+        }
+
+        throw new("Could not find connection type. Tried Microsoft.Data.SqlClient.SqlConnection, Npgsql.NpgsqlConnection, and MySqlConnector.MySqlConnection");
     }
 
     static Connection DiscoverConnection(HttpContext httpContext)

--- a/src/Delta/DeltaExtensions_ConnectionDiscovery.cs
+++ b/src/Delta/DeltaExtensions_ConnectionDiscovery.cs
@@ -27,7 +27,7 @@ public static partial class DeltaExtensions
             return (mySqlConnection, transaction);
         }
 
-        throw new("Could not find connection type. Tried Microsoft.Data.SqlClient.SqlConnection, Npgsql.NpgsqlConnection, and MySqlConnector.MySqlConnection");
+        throw new("Could not find connection type. Tried SqlConnection, NpgsqlConnection and MySqlConnection");
     }
 
     static Connection DiscoverConnection(HttpContext httpContext)


### PR DESCRIPTION
This checks the latest modification made on the MySQL/MariaDB instance; it is not specifically per table/row as it seems not to have support for it.

I didn't test on MySql, but for MariaDB, `gtid` must be enabled, in addition to having a `log_bin` set.